### PR TITLE
CA-18 | Remove parent dependencies sheet client

### DIFF
--- a/src/common/constants/index.ts
+++ b/src/common/constants/index.ts
@@ -6,6 +6,11 @@ export const isMongoIdPropValidator: ValidateOpts<unknown> = {
   validator: (value: unknown) => isMongoId(value),
 };
 
+export enum SortDirection {
+  ASC = 'asc',
+  DESC = 'desc',
+}
+
 export const PARAM_ID = 'id';
 
 export enum ATTRIBUTE_NAME_LENGTH {

--- a/src/common/interfaces/index.ts
+++ b/src/common/interfaces/index.ts
@@ -1,3 +1,5 @@
+import { SortDirection } from '../constants';
+
 export interface ITimestamps {
   createdAt: Date;
   updatedAt: Date;
@@ -53,4 +55,10 @@ export interface IApiResult {
 export interface IBasicQueryDto {
   limit?: number;
   skip?: number;
+}
+
+export interface IPaginationOptions {
+  limit?: number;
+  skip?: number;
+  sort?: SortDirection;
 }

--- a/src/modules/client/client.controller.ts
+++ b/src/modules/client/client.controller.ts
@@ -33,7 +33,6 @@ import {
 
 import { ClientDocument } from './schemas';
 import { ColoristId } from '../auth/decorators';
-import { CLIENT_POPULATE_OPTIONS } from './constants';
 
 @ApiTags('Client')
 @ApiBearerAuth()
@@ -82,7 +81,6 @@ export class ClientController {
       },
       undefined,
       {
-        ...CLIENT_POPULATE_OPTIONS,
         limit,
         skip,
       },
@@ -96,14 +94,10 @@ export class ClientController {
     @ParamMongoId(PARAM_ID) _id: string,
     @ColoristId() coloristId: string,
   ): Promise<ClientDocument> {
-    return this.clientService.findOne(
-      {
-        _id,
-        coloristId,
-      },
-      undefined,
-      CLIENT_POPULATE_OPTIONS,
-    );
+    return this.clientService.findOne({
+      _id,
+      coloristId,
+    });
   }
 
   @ApiOperationUpdateOneById()

--- a/src/modules/client/client.module.ts
+++ b/src/modules/client/client.module.ts
@@ -12,7 +12,7 @@ import { SheetModule } from '../sheet/sheet.module';
   exports: [ClientService],
   imports: [
     forwardRef(() => ColoristModule),
-    forwardRef(() => SheetModule),
+    SheetModule,
     MongooseModule.forFeature([{ name: Client.name, schema: ClientSchema }]),
   ],
   providers: [ClientService],

--- a/src/modules/client/constants/client.constant.ts
+++ b/src/modules/client/constants/client.constant.ts
@@ -1,7 +1,0 @@
-import { PopulateOptions } from 'mongoose';
-
-import { SHEET_POPULATE_OPTIONS } from '../../sheet/constants';
-
-export const CLIENT_POPULATE_OPTIONS: { populate: PopulateOptions } = {
-  populate: { path: 'sheets', ...SHEET_POPULATE_OPTIONS },
-};

--- a/src/modules/client/constants/index.ts
+++ b/src/modules/client/constants/index.ts
@@ -1,1 +1,0 @@
-export * from './client.constant';

--- a/src/modules/client/dtos/client.dto.ts
+++ b/src/modules/client/dtos/client.dto.ts
@@ -7,7 +7,6 @@ import {
 import {
   ATTRIBUTE_LAST_NAME_LENGTH,
   ATTRIBUTE_NAME_LENGTH,
-  ApiPropertyDto,
   ApiPropertyEmail,
   ApiPropertyLastName,
   ApiPropertyName,
@@ -23,8 +22,6 @@ import {
   IFindClientsQueryDto,
 } from '../interfaces';
 
-import { ISheet } from '../../sheet/interfaces';
-import { SheetDto } from '../../sheet/dtos';
 import { IsOptional, MaxLength } from 'class-validator';
 
 export class CreateClientDto implements ICreateClientDto {
@@ -47,11 +44,7 @@ export class UpdateClientDto
 
 export class ClientDto
   extends IntersectionType(CreateClientDto, BasicDocumentDto, ColoristIdDto)
-  implements IClientDto
-{
-  @ApiPropertyDto({ dto: SheetDto, isArray: true })
-  sheets: ISheet[];
-}
+  implements IClientDto {}
 
 export class FindClientsQueryDto
   extends BasicQueryDto

--- a/src/modules/client/interfaces/client.interface.ts
+++ b/src/modules/client/interfaces/client.interface.ts
@@ -1,7 +1,5 @@
 import { IBasicDocument, IBasicQueryDto, IColoristId } from '../../../common';
 
-import { ISheet } from '../../sheet/interfaces';
-
 export interface IClientId {
   clientId: string;
 }
@@ -13,23 +11,9 @@ export interface IClientAttributes extends IColoristId {
   phoneNumber?: string;
 }
 
-export interface IClientObjectIdAttributes {
-  sheets: ISheet[];
-}
+export interface IClient extends IClientAttributes, IBasicDocument {}
 
-interface IClientDtoObjectIdAttributes {
-  sheets: ISheet[];
-}
-
-export interface IClient
-  extends IClientAttributes,
-    IClientObjectIdAttributes,
-    IBasicDocument {}
-
-export interface IClientDto
-  extends IClientAttributes,
-    IClientDtoObjectIdAttributes,
-    IBasicDocument {}
+export interface IClientDto extends IClientAttributes, IBasicDocument {}
 
 /**
  * when creating a client, we will always have the sheets array empty.

--- a/src/modules/client/schemas/client.schema.ts
+++ b/src/modules/client/schemas/client.schema.ts
@@ -21,11 +21,12 @@ export class Client extends ColoristIdSchema implements IClientAttributes {
   @Prop({
     maxlength: ATTRIBUTE_EMAIL_LENGTH.MAX,
     minlength: ATTRIBUTE_EMAIL_LENGTH.MIN,
+    nullable: true,
     trim: true,
     type: String,
     validate: {
       message: (props: ValidatorProps) => `${props.value} is an invalid email`,
-      validator: (value: unknown) => isEmail(value),
+      validator: (value: unknown) => value == null || isEmail(value),
     },
   })
   email?: string;
@@ -51,6 +52,7 @@ export class Client extends ColoristIdSchema implements IClientAttributes {
   @Prop({
     maxlength: ATTRIBUTE_PHONE_NUMBER_LENGTH.MAX,
     minlength: ATTRIBUTE_PHONE_NUMBER_LENGTH.MIN,
+    nullable: true,
     trim: true,
     type: String,
   })

--- a/src/modules/client/schemas/client.schema.ts
+++ b/src/modules/client/schemas/client.schema.ts
@@ -1,9 +1,5 @@
 import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
-import {
-  Schema as MongooseSchema,
-  ValidatorProps,
-  HydratedDocument,
-} from 'mongoose';
+import { ValidatorProps, HydratedDocument } from 'mongoose';
 
 import {
   ATTRIBUTE_EMAIL_LENGTH,
@@ -13,24 +9,15 @@ import {
   ColoristIdSchema,
 } from '../../../common';
 
-import {
-  IClient,
-  IClientAttributes,
-  IClientObjectIdAttributes,
-} from '../interfaces';
-import { Sheet } from '../../sheet/schemas';
+import { IClient, IClientAttributes } from '../interfaces';
 import { isEmail } from 'class-validator';
-import { ISheet } from '../../sheet/interfaces';
 
 export type ClientDocument = HydratedDocument<IClient>;
 
 @Schema({
   timestamps: true,
 })
-export class Client
-  extends ColoristIdSchema
-  implements IClientAttributes, IClientObjectIdAttributes
-{
+export class Client extends ColoristIdSchema implements IClientAttributes {
   @Prop({
     maxlength: ATTRIBUTE_EMAIL_LENGTH.MAX,
     minlength: ATTRIBUTE_EMAIL_LENGTH.MIN,
@@ -68,17 +55,6 @@ export class Client
     type: String,
   })
   phoneNumber?: string;
-
-  @Prop({
-    type: [
-      {
-        ref: Sheet.name,
-        required: true,
-        type: MongooseSchema.Types.ObjectId,
-      },
-    ],
-  })
-  sheets: ISheet[];
 }
 
 export const ClientSchema = SchemaFactory.createForClass(Client);

--- a/src/modules/colorist/constants/colorist.constant.ts
+++ b/src/modules/colorist/constants/colorist.constant.ts
@@ -1,7 +1,6 @@
 import { PopulateOptions } from 'mongoose';
 
 import { IColorist } from '../interfaces';
-import { CLIENT_POPULATE_OPTIONS } from '../../client/constants';
 
 export enum COLORIST_HAIR_SALON_NAME_LENGTH {
   MIN = 3,
@@ -16,7 +15,6 @@ export enum COLORIST_PASSWORD_LENGTH {
 export const COLORIST_POPULATE_OPTIONS: { populate: PopulateOptions } = {
   populate: {
     path: 'clients',
-    ...CLIENT_POPULATE_OPTIONS,
   },
 };
 

--- a/src/modules/sheet/constants/sheet.constant.ts
+++ b/src/modules/sheet/constants/sheet.constant.ts
@@ -1,10 +1,4 @@
-import { PopulateOptions } from 'mongoose';
-
 export const SHEET_DATE_REGEX = /^\d{2}\/\d{2}\/\d{4}$/;
 export const SHEET_DATE_FORMAT = 'dd/MM/yyyy';
-
-export const SHEET_POPULATE_OPTIONS: { populate: PopulateOptions } = {
-  populate: { path: 'hairServices' },
-};
 
 export const SHEET_MAX_HAIR_SERVICES = 10;

--- a/src/modules/sheet/dtos/sheet.dto.ts
+++ b/src/modules/sheet/dtos/sheet.dto.ts
@@ -1,11 +1,17 @@
-import { ApiProperty, IntersectionType, PartialType } from '@nestjs/swagger';
-import { ArrayMaxSize, IsMongoId } from 'class-validator';
+import {
+  ApiProperty,
+  ApiPropertyOptional,
+  IntersectionType,
+  PartialType,
+} from '@nestjs/swagger';
+import { ArrayMaxSize, IsEnum, IsMongoId, IsOptional } from 'class-validator';
 
 import {
   ApiPropertyDto,
   BasicDocumentDto,
   BasicQueryDto,
   ColoristIdDto,
+  SortDirection,
 } from '../../../common';
 
 import {
@@ -53,7 +59,16 @@ export class SheetDto
 
 export class FindSheetsQueryDto
   extends BasicQueryDto
-  implements IFindSheetsQueryDto {}
+  implements IFindSheetsQueryDto
+{
+  @ApiPropertyOptional({
+    description: 'Sort sheets by date',
+    enum: SortDirection,
+  })
+  @IsOptional()
+  @IsEnum(SortDirection)
+  sort?: SortDirection;
+}
 
 export class ChangeClientDto implements IChangeClientDto {
   @ApiProperty({

--- a/src/modules/sheet/interfaces/sheet.interface.ts
+++ b/src/modules/sheet/interfaces/sheet.interface.ts
@@ -1,4 +1,9 @@
-import { IBasicDocument, IBasicQueryDto, IColoristId } from '../../../common';
+import {
+  IBasicDocument,
+  IBasicQueryDto,
+  IColoristId,
+  SortDirection,
+} from '../../../common';
 import { IClientId } from '../../client/interfaces';
 import { IHairService } from './hair-service.interface';
 
@@ -17,7 +22,9 @@ export type ICreateSheet = ISheetAttributes;
 
 export type ICreateSheetDto = Omit<ICreateSheet, 'coloristId'>;
 
-export type IFindSheetsQueryDto = IBasicQueryDto;
+export interface IFindSheetsQueryDto extends IBasicQueryDto {
+  sort?: SortDirection;
+}
 
 export interface IDeleteSheet extends IColoristId, ISheetId, IClientId {}
 

--- a/src/modules/sheet/sheet.controller.ts
+++ b/src/modules/sheet/sheet.controller.ts
@@ -83,19 +83,13 @@ export class SheetController {
     @Query() query: FindSheetsQueryDto,
     @ColoristId() coloristId: string,
   ): Promise<SheetDocument[]> {
-    const { limit, skip } = query;
+    const { limit, skip, sort } = query;
 
-    return this.sheetService.find(
-      {
-        clientId,
-        coloristId,
-      },
-      undefined,
-      {
-        limit,
-        skip,
-      },
-    );
+    return this.sheetService.findByClientId(clientId, coloristId, {
+      limit,
+      skip,
+      sort,
+    });
   }
 
   @ApiOperationUpdateOneById()

--- a/src/modules/sheet/sheet.controller.ts
+++ b/src/modules/sheet/sheet.controller.ts
@@ -42,7 +42,6 @@ import {
 
 import { SheetDocument } from './schemas';
 import { ColoristId } from '../auth/decorators';
-import { SHEET_POPULATE_OPTIONS } from './constants';
 import { ISheet } from './interfaces';
 
 @ApiTags('Sheet')
@@ -70,14 +69,10 @@ export class SheetController {
     @ParamMongoId(PARAM_ID) _id: string,
     @ColoristId() coloristId: string,
   ): Promise<SheetDocument> {
-    return this.sheetService.findOne(
-      {
-        _id,
-        coloristId,
-      },
-      undefined,
-      SHEET_POPULATE_OPTIONS,
-    );
+    return this.sheetService.findOne({
+      _id,
+      coloristId,
+    });
   }
 
   @ApiOperationFindAll(SheetDto, 'Finds all the sheets by client id')
@@ -98,7 +93,6 @@ export class SheetController {
       undefined,
       {
         limit,
-        ...SHEET_POPULATE_OPTIONS,
         skip,
       },
     );

--- a/src/modules/sheet/sheet.module.ts
+++ b/src/modules/sheet/sheet.module.ts
@@ -1,16 +1,14 @@
-import { Module, forwardRef } from '@nestjs/common';
+import { Module } from '@nestjs/common';
 import { MongooseModule } from '@nestjs/mongoose';
 
 import { SheetService } from './sheet.service';
 import { SheetController } from './sheet.controller';
 import { Sheet, SheetSchema } from './schemas';
-import { ClientModule } from '../client/client.module';
 
 @Module({
   controllers: [SheetController],
   exports: [SheetService],
   imports: [
-    forwardRef(() => ClientModule),
     MongooseModule.forFeature([{ name: Sheet.name, schema: SheetSchema }]),
   ],
   providers: [SheetService],

--- a/src/modules/sheet/sheet.service.ts
+++ b/src/modules/sheet/sheet.service.ts
@@ -3,7 +3,11 @@ import { Model } from 'mongoose';
 import { InjectModel } from '@nestjs/mongoose';
 import { UpdateResult } from 'mongodb';
 
-import { AbstractService } from '../../common';
+import {
+  AbstractService,
+  IPaginationOptions,
+  SortDirection,
+} from '../../common';
 
 import {
   IChangeClient,
@@ -21,6 +25,37 @@ export class SheetService extends AbstractService<ICreateSheet, SheetDocument> {
     protected model: Model<SheetDocument>,
   ) {
     super(SheetService.name, model);
+  }
+
+  async findByClientId(
+    clientId: string,
+    coloristId: string,
+    options?: IPaginationOptions,
+  ): Promise<SheetDocument[]> {
+    const filter = { clientId, coloristId };
+    const { limit, skip, sort } = options ?? {};
+
+    if (sort) {
+      return this.model.aggregate([
+        { $match: filter },
+        {
+          $addFields: {
+            dateAsDate: {
+              $dateFromString: {
+                dateString: '$date',
+                format: '%d/%m/%Y',
+              },
+            },
+          },
+        },
+        { $sort: { dateAsDate: sort === SortDirection.ASC ? 1 : -1 } },
+        { $limit: limit ?? 0 },
+        { $skip: skip ?? 0 },
+        { $project: { dateAsDate: 0 } },
+      ]);
+    }
+
+    return this.find(filter, undefined, { limit, skip });
   }
 
   async changeClient({

--- a/src/modules/sheet/sheet.service.ts
+++ b/src/modules/sheet/sheet.service.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable, forwardRef } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { Model } from 'mongoose';
 import { InjectModel } from '@nestjs/mongoose';
 import { UpdateResult } from 'mongodb';
@@ -13,130 +13,37 @@ import {
 } from './interfaces';
 
 import { Sheet, SheetDocument } from './schemas';
-import { ClientService } from '../client/client.service';
-import { ICreateClient } from '../client/interfaces';
-import { ClientDocument } from '../client/schemas';
 
 @Injectable()
 export class SheetService extends AbstractService<ICreateSheet, SheetDocument> {
   constructor(
     @InjectModel(Sheet.name)
     protected model: Model<SheetDocument>,
-    @Inject(forwardRef(() => ClientService))
-    private readonly clientService: ClientService,
   ) {
     super(SheetService.name, model);
   }
 
-  /**
-   * @async
-   * @param {IChangeClient} options
-   * @returns {Promise<UpdateResult>}
-   */
   async changeClient({
     coloristId,
     newClientId,
     oldClientId,
     sheetId,
   }: IChangeClient): Promise<UpdateResult> {
-    await this.assertParentExist<ICreateClient, ClientDocument, ClientService>(
-      newClientId,
-      this.clientService,
+    return this.updateOne(
+      { _id: sheetId, clientId: oldClientId, coloristId },
+      { $set: { clientId: newClientId } },
     );
-
-    const session = await this.model.startSession();
-    session.startTransaction();
-
-    try {
-      // set the sheet on the new client and change the hair services
-      // to the new client too
-      await this.clientService.updateOne(
-        { _id: newClientId, coloristId },
-        { $push: { sheets: sheetId } },
-        session,
-      );
-
-      // once the new client has the sheet, we remove it from the "old" client
-      const updatedClient = await this.clientService.updateOne(
-        { _id: oldClientId, coloristId },
-        { $pull: { sheets: sheetId } },
-        session,
-      );
-
-      await session.commitTransaction();
-      return updatedClient;
-    } catch (error) {
-      this.logger.error('Error while changing sheet from client', {
-        coloristId,
-        error,
-        newClientId,
-        oldClientId,
-      });
-
-      await session.abortTransaction();
-      throw error;
-    } finally {
-      await session.endSession();
-    }
   }
 
-  /**
-   * Creates a sheet and updates the client document to have this new sheet.
-   *
-   * @async
-   * @param {ICreateSheet} sheetData
-   * @returns {Promise<ISheet>} The created sheet
-   */
   async createSheet(sheetData: ICreateSheet): Promise<ISheet> {
-    return this.createAndUpdateParent<
-      ICreateClient,
-      ClientDocument,
-      ClientService
-    >(sheetData, this.clientService, sheetData.clientId, 'sheets');
+    return this.create(sheetData);
   }
 
-  /**
-   * Deletes a sheet, all the hair services that belongs to it
-   * and updates the client to not have this id anymore.
-   *
-   * @async
-   * @param {IDeleteSheet} options
-   * @returns {Promise<void>}
-   */
   async deleteSheet({
     clientId,
     coloristId,
     sheetId,
   }: IDeleteSheet): Promise<void> {
-    await this.assertParentExist<ICreateClient, ClientDocument, ClientService>(
-      clientId,
-      this.clientService,
-    );
-
-    const session = await this.model.startSession();
-    session.startTransaction();
-
-    try {
-      await this.deleteOne({ _id: sheetId, coloristId }, session);
-      await this.clientService.updateOne(
-        { _id: clientId, coloristId },
-        { $pull: { sheets: sheetId } },
-        session,
-      );
-
-      await session.commitTransaction();
-    } catch (error) {
-      this.logger.error('Could not delete sheet', {
-        clientId,
-        coloristId,
-        error,
-        sheetId,
-      });
-
-      await session.abortTransaction();
-      throw error;
-    } finally {
-      await session.endSession();
-    }
+    await this.deleteOne({ _id: sheetId, clientId, coloristId });
   }
 }


### PR DESCRIPTION
- Removed the bidirectional relationship between Clients and Sheets. Now, only Sheets contain a `clientId`; Clients no longer hold an array of `sheetIds`.
- **Bug fix:** `changeClient` now correctly updates the `clientId` within the Sheet document (previously, it only updated in-memory arrays without persisting changes).
- Fix in email/phone validations: Added support for `null` values (Client model).
- Added support for sorting sheets by date.