### PR TITLE
CA-26 | example is not working

### DIFF
--- a/src/modules/colorist/dtos/colorist.dto.ts
+++ b/src/modules/colorist/dtos/colorist.dto.ts
@@ -88,7 +88,7 @@ export class CreateColoristResponseDto
 export class ColoristSignInDto implements IColoristSignInDto {
   @ApiProperty({
     description: 'Value to find the colorist',
-    examples: ['CarlaColor', 'carla@gmail.com'],
+    example: 'carla@gmail.com',
     maxLength: ATTRIBUTE_EMAIL_LENGTH.MAX,
     minLength: ATTRIBUTE_EMAIL_LENGTH.MIN,
   })


### PR DESCRIPTION
When creating the api property for `emailOrUsername` we realized is not working as expected for multiple example; we keep one example