### PR TITLE
CA-30 | bug fix: sheet date validation

### DIFF
--- a/src/modules/sheet/dtos/sheet.dto.ts
+++ b/src/modules/sheet/dtos/sheet.dto.ts
@@ -6,7 +6,7 @@ import {
 } from '@nestjs/swagger';
 import {
   ArrayMaxSize,
-  IsDate,
+  IsDateString,
   IsEnum,
   IsMongoId,
   IsOptional,
@@ -50,7 +50,7 @@ export class CreateSheetDto implements ICreateSheetDto {
     description: 'Sheet date',
     example: '2023-05-29T00:00:00.000Z',
   })
-  @IsDate()
+  @IsDateString()
   date: Date;
 }
 


### PR DESCRIPTION
DTO validation must be a date string since in the request HTTP the dates are iso strings 